### PR TITLE
vector::erase invalidates any iterators at/after the erase position

### DIFF
--- a/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
+++ b/runtime/Cpp/runtime/src/misc/IntervalSet.cpp
@@ -128,7 +128,7 @@ void IntervalSet::add(const Interval &addition) {
         }
 
         // if we bump up against or overlap next, merge
-        _intervals.erase(iterator);// remove this one
+        iterator = _intervals.erase(iterator);// remove this one
         --iterator; // move backwards to what we just set
         *iterator = bigger.Union(next); // set to 3 merged ones
         // ml: no need to advance iterator, we do that in the next round anyway. ++iterator; // first call to next after previous duplicates the result


### PR DESCRIPTION
The erase causes a crash in my application as `iterator` has been invalidated.