### PR TITLE
Compare contents not just addresses

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.cpp
@@ -101,12 +101,15 @@ void ATNConfig::setPrecedenceFilterSuppressed(bool value) {
   }
 }
 
-bool ATNConfig::operator == (const ATNConfig &other) const
-{
+bool ATNConfig::operator == (const ATNConfig &other) const {
   return state->stateNumber == other.state->stateNumber && alt == other.alt &&
-    (context == other.context || (context != nullptr && context == other.context)) &&
-    semanticContext == other.semanticContext &&
+    (context == other.context || (context != nullptr && *context == *(other.context))) &&
+    (semanticContext == other.semanticContext || (semanticContext != nullptr && *semanticContext == *(other.semanticContext))) &&
     isPrecedenceFilterSuppressed() == other.isPrecedenceFilterSuppressed();
+}
+
+bool ATNConfig::operator != (const ATNConfig &other) const {
+  return !operator==(other);
 }
 
 std::string ATNConfig::toString() {

--- a/runtime/Cpp/runtime/src/atn/ATNConfig.h
+++ b/runtime/Cpp/runtime/src/atn/ATNConfig.h
@@ -129,6 +129,7 @@ namespace atn {
     /// the same state, they predict the same alternative, and
     /// syntactic/semantic contexts are the same.
     bool operator == (const ATNConfig &other) const;
+    bool operator != (const ATNConfig &other) const;
 
     virtual std::string toString();
     std::string toString(bool showAlt);

--- a/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNConfigSet.cpp
@@ -164,17 +164,17 @@ bool ATNConfigSet::operator == (const ATNConfigSet &other) {
   if (configs.size() != other.configs.size())
     return false;
 
+  if (fullCtx != other.fullCtx || uniqueAlt != other.uniqueAlt ||
+      conflictingAlts != other.conflictingAlts || hasSemanticContext != other.hasSemanticContext ||
+      dipsIntoOuterContext != other.dipsIntoOuterContext) // includes stack context
+    return false;
+
   for (size_t i = 0; i < configs.size(); i++) {
-    if (configs[i] != other.configs[i]) {
+    if (configs[i] != other.configs[i] && *(configs[i]) != *(other.configs[i]))
       return false;
-    }
   }
 
-  bool same = fullCtx == other.fullCtx && uniqueAlt == other.uniqueAlt &&
-    conflictingAlts == other.conflictingAlts && hasSemanticContext == other.hasSemanticContext &&
-    dipsIntoOuterContext == other.dipsIntoOuterContext; // includes stack context
-
-  return same;
+  return true;
 }
 
 size_t ATNConfigSet::hashCode() {

--- a/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerATNConfig.cpp
@@ -89,10 +89,13 @@ size_t LexerATNConfig::hashCode() const {
 
 bool LexerATNConfig::operator == (const LexerATNConfig& other) const
 {
+  if (this == &other)
+    return true;
+
   if (_passedThroughNonGreedyDecision != other._passedThroughNonGreedyDecision)
     return false;
 
-  if (_lexerActionExecutor != other._lexerActionExecutor) {
+  if (_lexerActionExecutor != other._lexerActionExecutor && (_lexerActionExecutor != nullptr && *_lexerActionExecutor != *(other._lexerActionExecutor))) {
     return false;
   }
 

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.cpp
@@ -115,6 +115,10 @@ bool LexerActionExecutor::operator == (const LexerActionExecutor &obj) const {
   return _hashCode == obj._hashCode && Arrays::equals(_lexerActions, obj._lexerActions);
 }
 
+bool LexerActionExecutor::operator != (const LexerActionExecutor &obj) const {
+  return !operator==(obj);
+}
+
 size_t LexerActionExecutor::generateHashCode() const {
   size_t hash = MurmurHash::initialize();
   for (auto lexerAction : _lexerActions) {

--- a/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
+++ b/runtime/Cpp/runtime/src/atn/LexerActionExecutor.h
@@ -125,6 +125,7 @@ namespace atn {
 
     virtual size_t hashCode() const;
     virtual bool operator == (const LexerActionExecutor &obj) const;
+    virtual bool operator != (const LexerActionExecutor &obj) const;
 
   private:
     const std::vector<Ref<LexerAction>> _lexerActions;

--- a/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
+++ b/runtime/Cpp/runtime/src/atn/SemanticContext.cpp
@@ -65,14 +65,10 @@ size_t SemanticContext::Predicate::hashCode() const {
 }
 
 bool SemanticContext::Predicate::operator == (const SemanticContext &other) const {
-  const Predicate *p = dynamic_cast<const Predicate*>(&other);
-  if (p == nullptr)
-    return false;
-
-  if (this == p) {
+  if (this == &other)
     return true;
-  }
 
+  const Predicate *p = dynamic_cast<const Predicate*>(&other);
   if (p == nullptr)
     return false;
 
@@ -116,13 +112,12 @@ size_t SemanticContext::PrecedencePredicate::hashCode() const {
 }
 
 bool SemanticContext::PrecedencePredicate::operator == (const SemanticContext &other) const {
+  if (this == &other)
+    return true;
+
   const PrecedencePredicate *predicate = dynamic_cast<const PrecedencePredicate *>(&other);
   if (predicate == nullptr)
     return false;
-
-  if (this == predicate) {
-    return true;
-  }
 
   return precedence == predicate->precedence;
 }
@@ -172,15 +167,21 @@ std::vector<Ref<SemanticContext>> SemanticContext::AND::getOperands() const {
 }
 
 bool SemanticContext::AND::operator == (const SemanticContext &other) const {
+  if (this == &other)
+    return true;
+
   const AND *context = dynamic_cast<const AND *>(&other);
   if (context == nullptr)
     return false;
 
-  if (this == context) {
+  if (opnds == context->opnds)
     return true;
-  }
 
-  return opnds == context->opnds;
+  for (auto opndIt = opnds.begin(), otherIt = context->opnds.begin(); opndIt < opnds.end(), otherIt < context->opnds.end(); ++opndIt, ++otherIt) {
+    if (*opndIt != *otherIt)
+      return false;
+  }
+  return true;
 }
 
 size_t SemanticContext::AND::hashCode() const {
@@ -275,15 +276,21 @@ std::vector<Ref<SemanticContext>> SemanticContext::OR::getOperands() const {
 }
 
 bool SemanticContext::OR::operator == (const SemanticContext &other) const {
+  if (this == &other)
+    return true;
+
   const OR *context = dynamic_cast<const OR *>(&other);
   if (context == nullptr)
     return false;
 
-  if (this == context) {
+  if (opnds == context->opnds)
     return true;
-  }
 
-  return opnds == context->opnds;
+  for (auto opndIt = opnds.begin(), otherIt = context->opnds.begin(); opndIt < opnds.end(), otherIt < context->opnds.end(); ++opndIt, ++otherIt ) {
+    if (*opndIt != *otherIt)
+      return false;
+  }
+  return true;
 }
 
 size_t SemanticContext::OR::hashCode() const {


### PR DESCRIPTION
Fixes the GCC slowdown #25 - now Linux build (GCC 6.1.1) runs my test ~15% faster than Windows (VS 2015 update 3) - aggressive optimisations in both cases.  Previously Linux was over 100 times slower.