### PR TITLE
Remove the std::operator== override in CPPUtils.h

### DIFF
--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -483,7 +483,7 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
             continue;
           }
 
-          if (transition->target == endState || *(transition->target) == *endState) {
+          if (transition->target == endState) {
             transition->target = bypassStop;
           }
         }

--- a/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
+++ b/runtime/Cpp/runtime/src/atn/ATNDeserializer.cpp
@@ -483,7 +483,7 @@ ATN ATNDeserializer::deserialize(const std::vector<uint16_t>& input) {
             continue;
           }
 
-          if (transition->target == endState) {
+          if (transition->target == endState || *(transition->target) == *endState) {
             transition->target = bypassStop;
           }
         }

--- a/runtime/Cpp/runtime/src/support/CPPUtils.h
+++ b/runtime/Cpp/runtime/src/support/CPPUtils.h
@@ -85,28 +85,3 @@ namespace antlrcpp {
   std::string what(std::exception_ptr eptr = std::current_exception());
 
 } // namespace antlrcpp
-
-namespace std {
-  // Comparing weak and shared pointers.
-  template <typename T>
-  bool operator == (const std::weak_ptr<T> &lhs, const std::weak_ptr<T> &rhs) {
-    if (lhs.expired() && rhs.expired())
-      return true;
-
-    if (lhs.expired() || rhs.expired())
-      return false;
-
-    return (lhs.lock() == rhs.lock());
-  }
-
-  template <typename T>
-  bool operator == (const Ref<T> &lhs, const Ref<T> &rhs) {
-    if (!lhs && !rhs)
-      return true;
-
-    if (!lhs || !rhs)
-      return false;
-
-    return (*lhs == *rhs);
-  }
-} // namespace std


### PR DESCRIPTION
This removes the operator == override in CPPUtils.h and adds an additional test in ATNDeserializer.cpp.  I haven't found any other cases where the additional testing is required.

I am comparing the results of C++ and Java parsing by calling toStringTree() and doing a direct text comparison... in 10 out of my 3665 inputs, the string output does not match.  However, it's the exact same mismatch with or without this operator== removal so I consider this patch to be safe to apply without detrimental effects.

The differences look like they may just be caused by incorrect handling of 3+ bytes characters in both the C++ and the Java runtimes (possibly just during the string output)... I'll continue to investigate.